### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "bash"
+run = "docker pull docker.pkg.github.com/checkra1n/pongoos/build-pongo:latest"

--- a/README.md
+++ b/README.md
@@ -26,3 +26,5 @@ Kernel patchfinder
 ------------------
 
 Note that the checkra1n patchfinder is not currently open-source. However, the KPF JIT that will ship on checkra1n 0.10.0 onwards is part of this repository. That means that pongoOS builds from this repository will always boot to the shell by default instead of XNU.
+
+[![Run on Repl.it](https://repl.it/badge/github/checkra1n/pongoOS)](https://repl.it/github/checkra1n/pongoOS)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).