### PR TITLE
Fix macho loading

### DIFF
--- a/scripts/module_load.py
+++ b/scripts/module_load.py
@@ -19,7 +19,8 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-# 
+#
+import struct
 import sys
 data = open(sys.argv[1], "rb").read()
 import usb.core
@@ -29,7 +30,7 @@ if dev is None:
 dev.set_configuration()
 
 dev.ctrl_transfer(0x21, 2, 0, 0, 0)
-dev.ctrl_transfer(0x21, 1, 0, 0, 0)
+dev.ctrl_transfer(0x21, 1, 0, 0, struct.pack('I', len(data)))
 dev.write(2,data,100000)
 if len(data) % 512 == 0:
 	dev.write(2,"")

--- a/src/dynamic/modload_macho.c
+++ b/src/dynamic/modload_macho.c
@@ -107,15 +107,15 @@ void modload_cmd() {
                             lc = (struct load_command*)(((char*)lc) + lc->cmdsize);
                         }
                         
-                        const struct relocation_info *extrel = (void *)((uintptr_t)loader_xfer_recv_data + dysymtab->extreloff);
-                        const struct relocation_info *locrel = (void *)((uintptr_t)loader_xfer_recv_data + dysymtab->locreloff);
-                        const struct nlist_64 *nlist = (struct nlist_64 *)((uintptr_t)loader_xfer_recv_data + symtab->symoff);
+                        const struct relocation_info *extrel = (void *)((uintptr_t)mh + dysymtab->extreloff);
+                        const struct relocation_info *locrel = (void *)((uintptr_t)mh + dysymtab->locreloff);
+                        const struct nlist_64 *nlist = (struct nlist_64 *)((uintptr_t)mh + symtab->symoff);
                         const char** modname = NULL;
                         struct pongo_exports* exports = NULL;
                         for (uint32_t sym_idx = 0; sym_idx < symtab->nsyms; sym_idx++) {
                             const struct nlist_64 *nl = &nlist[sym_idx];
                             uint32_t strx = nl->n_un.n_strx;
-                            const char *name = (const char *)((uintptr_t)loader_xfer_recv_data + symtab->stroff + strx);
+                            const char *name = (const char *)((uintptr_t)mh + symtab->stroff + strx);
                             // Check to see if this is the entry point symbol.
                             int cmp = strcmp(name, "_module_entry");
                             if (cmp == 0) {


### PR DESCRIPTION
- Added the data length in module_load.py 
- Fixed an uninitialized variable that wouldn't allow a panic to happen when `_module_entry` wasn't found 
- Changed some bases to go off the mac header