### PR TITLE
Load m1n1 at top of kernel data

### DIFF
--- a/src/drivers/xnu/xnu.c
+++ b/src/drivers/xnu/xnu.c
@@ -1127,7 +1127,6 @@ void xnu_boot(void)
     {
         panic("Cannot boot XNU with TZ0 unlocked");
     }*/
-    gBootArgs->topOfKernelData = gTopOfKernelData;
 }
 
 void xnu_init(void)

--- a/src/shell/main.c
+++ b/src/shell/main.c
@@ -46,6 +46,7 @@ void pongo_boot_raw(const char *cmd, char *args) {
     task_yield();
 }
 
+uint64_t gM1N1Base;
 extern char gFWVersion[256];
 void pongo_boot_m1n1(const char *cmd, char *args) {
     if (!loader_xfer_recv_count) {
@@ -53,9 +54,13 @@ void pongo_boot_m1n1(const char *cmd, char *args) {
         return;
     }
 
-    loader_xfer_recv_count = 0;
     char *fwversion = dt_get_prop("/chosen", "firmware-version", NULL);
     strlcpy(fwversion, gFWVersion, 256);
+
+    void *m1n1 = alloc_static(loader_xfer_recv_count);
+    memmove(m1n1, loader_xfer_recv_data, loader_xfer_recv_count);
+    loader_xfer_recv_count = 0;
+    gM1N1Base = vatophys_static(m1n1);
 
     gBootFlag = BOOT_FLAG_M1N1;
     task_yield();


### PR DESCRIPTION
m1n1 expects itself to be loaded below top of kernel data, so load it right at top of kernel data and then update top of kernel so that it is below top of kernel data.

In particular, its memory allocator start at topOfKernelData and assumes all memory between that and physBase + memSize is free. More severely, the chainloading scripts will derive new topOfKernelData from the current m1n1, so the current approach of loading would actually cause chainloading to set topOfKernelData to near the end of memory, causing problems.