### PR TITLE
Fix Linux build compilation errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,12 +32,14 @@ ifeq ($(HOST_OS),Darwin)
 	EMBEDDED_CC         ?= xcrun -sdk iphoneos clang
 	STRIP               ?= strip
 	STAT                ?= stat -L -f %z
+	LTO_FLAG            ?= -flto
 else
 ifeq ($(HOST_OS),Linux)
 	EMBEDDED_CC         ?= clang
 	EMBEDDED_LDFLAGS    ?= -fuse-ld=/usr/bin/ld64
 	STRIP               ?= cctools-strip
 	STAT                ?= stat -L -c %s
+	LTO_FLAG            ?=
 endif
 endif
 
@@ -52,7 +54,7 @@ RA1N                    := checkra1n/kpf
 
 # General options
 EMBEDDED_LD_FLAGS       ?= -nostdlib -static -Wl,-fatal_warnings -Wl,-dead_strip -Wl,-Z $(EMBEDDED_LDFLAGS)
-EMBEDDED_CC_FLAGS       ?= --target=arm64-apple-ios12.0 -std=gnu17 -Wall -Wunused-label -Werror -O3 -flto -ffreestanding -U__nonnull -nostdlibinc -DTARGET_OS_OSX=0 -DTARGET_OS_MACCATALYST=0 -I$(LIB)/include $(EMBEDDED_LD_FLAGS) $(EMBEDDED_CFLAGS)
+EMBEDDED_CC_FLAGS       ?= --target=arm64-apple-ios12.0 -std=gnu17 -Wall -Wunused-label -Werror -O3 $(LTO_FLAG) -ffreestanding -U__nonnull -nostdlibinc -DTARGET_OS_OSX=0 -DTARGET_OS_MACCATALYST=0 -I$(LIB)/include $(EMBEDDED_LD_FLAGS) $(EMBEDDED_CFLAGS)
 
 # Pongo options
 PONGO_LDFLAGS           ?= -L$(LIB)/lib -lc -lm -Wl,-preload -Wl,-no_uuid -Wl,-e,start -Wl,-order_file,$(SRC)/sym_order.txt -Wl,-image_base,0x100000000 -Wl,-sectalign,__DATA,__common,0x8 -Wl,-segalign,0x4000

--- a/checkra1n/kpf/main.c
+++ b/checkra1n/kpf/main.c
@@ -1657,10 +1657,8 @@ void command_kpf() {
     xnu_pf_emit(xnu_data_const_patchset);
     xnu_pf_apply(data_const_range, xnu_data_const_patchset);
     xnu_pf_patchset_destroy(xnu_data_const_patchset);
-    bool is_unified = true;
 
     if (!has_found_sbops) {
-        is_unified = false;
         if (!plk_text_range) panic("no plk_text_range");
         xnu_pf_patchset_t* xnu_plk_data_const_patchset = xnu_pf_patchset_create(XNU_PF_ACCESS_64BIT);
         xnu_pf_ptr_to_data(xnu_plk_data_const_patchset, xnu_slide_value(hdr), plk_text_range, "Seatbelt sandbox policy", strlen("Seatbelt sandbox policy")+1, true, (void*)sb_ops_callback);
@@ -1890,10 +1888,8 @@ void kpf_autoboot() {
 
         ramdisk_size = rdsksz + 0x10000;
 
-        char should_populate_kerninfo = 0;
         struct kerninfo *info = (struct kerninfo*)(ramdisk_buf+rdsksz);
         if (info->size == sizeof(struct kerninfo)) {
-            should_populate_kerninfo = 1;
         } else {
             printf("Detected corrupted kerninfo!\n");
             return;

--- a/src/drivers/sep/sep.c
+++ b/src/drivers/sep/sep.c
@@ -910,7 +910,7 @@ struct sep_command {
     void (*cb)(const char* cmd, char* args);
 };
 
-void sep_help();
+void sep_help(const char* cmd, char* args);
 #define SEP_COMMAND(_name, _desc, _cb) {.name = _name, .desc = _desc, .cb = _cb}
 void sep_pwned_peek(const char* cmd, char* args) {
     if(!sep_is_pwned) {

--- a/src/kernel/mm.c
+++ b/src/kernel/mm.c
@@ -371,13 +371,11 @@ err_t vm_allocate(struct vm_space* vmspace, uint64_t* addr, uint64_t size, vm_fl
     uint32_t vm_scan_base = 0;
     uint64_t vm_scan_size = (VM_SPACE_SIZE / PAGE_SIZE);
     uint32_t found_pages = 0;
-    uint32_t vm_index_start = 0;
 
     if (flags & VM_FLAGS_FIXED) {
         uint64_t vm_offset = *addr - vmspace->vm_space_base;
         if (vm_offset > vmspace->vm_space_end) vm_scan_size = 0;
         else {
-            vm_index_start = vm_offset / PAGE_SIZE;
             vm_scan_size = ((size + PAGE_MASK) & ~PAGE_MASK) / PAGE_SIZE;
         }
     } else {
@@ -931,18 +929,15 @@ void ttbpage_free_walk(uint64_t base, bool is_tt1) {
 }
 bool tte_walk_get(struct vm_space* vmspace, uint64_t va, uint64_t** tte_out) {
     uint64_t bits = 64ULL;
-    bool is_tt1 = false;
     uint64_t* ttb = NULL;
     if (va & 0x7000000000000000) {
         bits -= t1sz;
         va -= (0xffffffffffffffff - ((1ULL << (65 - t1sz)) - 1));
         va &= (1ULL << bits) - 1;
-        is_tt1 = true;
         ttb = phystokv(vmspace->ttbr1);
     } else {
         bits -= t0sz;
         va &= (1ULL << bits) - 1;
-        is_tt1 = false;
         ttb = phystokv(vmspace->ttbr0);
     }
     uint32_t levels = ((bits - (tt_bits + 3ULL)) / tt_bits);

--- a/src/kernel/task.c
+++ b/src/kernel/task.c
@@ -26,6 +26,7 @@
  */
 #include <errno.h>
 #include <stdlib.h>
+#include <stdarg.h>
 #include <pongo.h>
 
 extern void task_load(struct task* to_task);


### PR DESCRIPTION
## Summary

This PR fixes compilation errors that prevent building PongoOS on Linux. The project was previously only buildable on macOS due to several code issues and LTO incompatibilities with the Linux ld64 linker.

## Changes Made

### Code Fixes (Commit 1effce3)
- Added missing `#include <stdarg.h>` to `src/kernel/task.c` (required for `va_start`/`va_end`)
- Removed unused variables in `src/kernel/mm.c` (`vm_index_start`, `is_tt1`) that caused `-Werror` failures
- Fixed function declaration mismatch in `src/drivers/sep/sep.c` (`sep_help()` → `sep_help(const char*, char*)`)
- Removed unused variables in `checkra1n/kpf/main.c` (`is_unified`, `should_populate_kerninfo`)

### Build Configuration (Commit 7dec8a1)
- Added platform-specific LTO flag handling in Makefile
- macOS: Keeps `-flto` for optimization
- Linux: Disables LTO due to ld64 libLTO.so incompatibility
- Changes are backward compatible

## Testing

✅ **Before:** 6 compilation errors, build fails  
✅ **After:** 0 errors, 0 warnings, successful build  

All build artifacts generated successfully:
- build/Pongo (741K)
- build/Pongo.bin (645K)
- build/PongoConsolidated.bin (731K)
- build/checkra1n-kpf-pongo (86K)

## Impact

- ✅ Enables building on Linux (currently macOS-only)
- ✅ Fixes compilation warnings treated as errors
- ✅ No functional changes or regressions
- ✅ Minimal code changes (11 lines removed, 5 added)

## Setup Instructions for Linux Users

1. Install build dependencies:
```bash
sudo apt-get install clang cctools-strip libblocksruntime0
curl -sL "https://github.com/checkra1n/ld64-build/releases/download/954.16-0/ld64-x86_64" -o /tmp/ld64-x86_64
chmod +x /tmp/ld64-x86_64
sudo cp /tmp/ld64-x86_64 /usr/bin/ld64
```

2. Build:
```bash
make all
```

All build artifacts will be in `build/` directory.